### PR TITLE
Refactor cp-issuer-secret to use SecretShare

### DIFF
--- a/scripts/cp4mcm-rhacm21-cp-issuer-secret.sh
+++ b/scripts/cp4mcm-rhacm21-cp-issuer-secret.sh
@@ -29,10 +29,10 @@ apiVersion: ibmcpcs.ibm.com/v1
 kind: SecretShare
 metadata:
   name: $SECRETSHARE
-  namespace: ibm-common-services
+  namespace: $CS_NS
 spec:
   secretshares:
-  - secretname: cs-ca-certificate-secret
+  - secretname: $ISSUER_SECRET
     sharewith:
     - namespace: $ISSUER_NS
 EOF

--- a/scripts/cp4mcm-rhacm21-cp-issuer-secret.sh
+++ b/scripts/cp4mcm-rhacm21-cp-issuer-secret.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
   
-ISSUER_NS=open-cluster-management-issuer
+ACM_ISSUER_NS=open-cluster-management-issuer
 CS_NS=ibm-common-services
-ISSUER_SECRET=cs-ca-certificate-secret
+CS_ISSUER_SECRET=cs-ca-certificate-secret
 SECRETSHARE=cert-manager
 INTERVAL=5
 TESTCOUNT=720
@@ -32,9 +32,9 @@ metadata:
   namespace: $CS_NS
 spec:
   secretshares:
-  - secretname: $ISSUER_SECRET
+  - secretname: $CS_ISSUER_SECRET
     sharewith:
-    - namespace: $ISSUER_NS
+    - namespace: $ACM_ISSUER_NS
 EOF
 
 if [[ "$?" -ne 0 ]];then

--- a/scripts/cp4mcm-rhacm21-cp-issuer-secret.sh
+++ b/scripts/cp4mcm-rhacm21-cp-issuer-secret.sh
@@ -7,17 +7,19 @@ SECRETSHARE=cert-manager
 INTERVAL=5
 TESTCOUNT=720
 
-# TODO: oc or kubectl
-
-# Wait for SecretShare to be available
-while [[ "$result" -ne 0 && !( $TESTCOUNT == 0 ) ]]
+printf "Checking that SecretShare resource kind exists..."
+while [[ !( $result == 0 ) && !( $TESTCOUNT == 0 ) ]]
 do
   sleep $INTERVAL
-  result=`oc get secretshare.ibmcpcs.ibm.com -n $CS_NS &>/dev/null`
+  oc get secretshare.ibmcpcs.ibm.com -n $CS_NS &>/dev/null
+  result=$?
   TESTCOUNT=$(( $TESTCOUNT - 1 ))
+  printf "."
 done
 
-if [[ "$result" -ne 0 ]];then
+echo
+
+if [[ !( $result == 0 ) ]];then
   echo "Timeout, failed to find secretshare kind. Ensure the IBM Common Services operator has been installed."
   exit 1
 fi


### PR DESCRIPTION
Update the cp-issuer-secret script to use the SecretShare mechanism from IBM Common Services to copy the secret without ownerReferences.