### PR TITLE
Update cp4mcm-cleanup-utility.sh

### DIFF
--- a/scripts/cp4mcm-cleanup-utility.sh
+++ b/scripts/cp4mcm-cleanup-utility.sh
@@ -644,6 +644,7 @@ deleteSecrets() {
 	"sre-inventory-inventory-rhacm-redisgraph-user-secrets"
 	"sre-inventory-redisgraph-secrets"
 	"sre-inventory-redisgraph-user-secrets"
+	"sre-inventory-redisgraph-user-conf-secrets"
 	"sre-inventory-search-api-secrets"
 	"sre-postgresql-bastion-secret"
 	"sre-postgresql-vault-secret"


### PR DESCRIPTION
in release 2.3, one more secret sre-inventory-redisgraph-user-conf-secrets is created, need to delete it together with sre-inventory-redisgraph-user-secrets