### PR TITLE
Updated Restore docs

### DIFF
--- a/bcdr/restore/RestoreAllComponents.md
+++ b/bcdr/restore/RestoreAllComponents.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Install the `watch`, `kubectl`, `oc`, `python`, `velero`, `Helm`, `jq`, `git` and `cloudctl` CLIs on the workstation machine, where you can access the OpenShift cluster, initiate and monitor the restoration of IBM Cloud Pak® for Multicloud Management.
-- If your environment has no access to Internet, you need to upload the `Nginx` image to all the worker nodes by following [Uploading the Nginx image in an air gap environment](../install/UploadNginxImageOnAirgap.md). The `Nginx` container is used to back up MongoDB that is running in the `ibm-common-services` namespace.
+- If your environment has no access to Internet, you need to upload the `Nginx` image to all the worker nodes by following [Uploading the Nginx image in an air gap environment](../install/UploadNginxImageOnAirgap.md). The `Nginx` container is used to restore MongoDB that is running in the `ibm-common-services` namespace.
 
 **Notes**
 

--- a/bcdr/restore/RestoreIndividualComponent.md
+++ b/bcdr/restore/RestoreIndividualComponent.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Install the `watch`, `kubectl`, `oc`, `python`, `velero`, `Helm`, `jq`, `git` and `cloudctl` CLIs on the workstation machine, where you can access the OpenShift cluster, initiate and monitor the restoration of IBM Cloud Pak® for Multicloud Management.
-- If your environment has no access to Internet, you need to upload the `Nginx` image to all the worker nodes by following [Uploading the Nginx image in an air gap environment](../install/UploadNginxImageOnAirgap.md). The `Nginx` container is used to back up MongoDB that is running in the `ibm-common-services` namespace.
+- If your environment has no access to Internet, you need to upload the `Nginx` image to all the worker nodes by following [Uploading the Nginx image in an air gap environment](../install/UploadNginxImageOnAirgap.md). The `Nginx` container is used to restore MongoDB that is running in the `ibm-common-services` namespace.
 
 **Notes**
 - Common Services restore needs to be performed in a fresh cluster.


### PR DESCRIPTION
Rephrased prerequisite section in both Restore docs. Replaced `back up` word with `restore`.