### PR TITLE
Add deletion commands for MutatingWebhookConfiguration and ValidatingWebhookConfiguration during cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,3 +86,8 @@ All notable changes to this project will be documented in this file.
 - Updated cp4mcm-ha-utility.sh script to support modules
   - infrastructure-management-grc
   - infrastructure-management-vm
+
+## [0.14.0] - 2022-05-26
+- Updated cp4mcm-cleanup-utility.sh and uninstall.sh scripts to include commands to delete MutatingWebhookConfiguration and ValidatingWebhookConfiguration objects
+  - `scripts/cp4mcm-cleanup-utility.sh`
+  - `scripts/uninstall.sh`

--- a/scripts/cp4mcm-cleanup-utility.sh
+++ b/scripts/cp4mcm-cleanup-utility.sh
@@ -788,9 +788,9 @@ secretConfigmapFunc() {
     result=$(( result + $? ))
     deleteResource "secret" "kube-system" "ibm-management-pull-secret" "true" 300
     result=$(( result + $? ))
-	deleteResourceInGlobalNamespace "mutatingwebhookconfiguration" "image-admission-config" "true" 300
+    deleteResourceInGlobalNamespace "mutatingwebhookconfiguration" "image-admission-config" "true" 300
     result=$(( result + $? ))
-	deleteResourceInGlobalNamespace "validatingwebhookconfiguration" "image-admission-config" "true" 300
+    deleteResourceInGlobalNamespace "validatingwebhookconfiguration" "image-admission-config" "true" 300
     result=$(( result + $? ))
     if [[ "${result}" -ne 0 ]]; then
 	return 1
@@ -826,9 +826,9 @@ postUninstallFunc() {
     result=$(( result + $? ))
     deleteResource "secret" "kube-system" "ibm-management-pull-secret" "true" 300
     result=$(( result + $? ))
-	deleteResourceInGlobalNamespace "mutatingwebhookconfiguration" "image-admission-config" "true" 300
+    deleteResourceInGlobalNamespace "mutatingwebhookconfiguration" "image-admission-config" "true" 300
     result=$(( result + $? ))
-	deleteResourceInGlobalNamespace "validatingwebhookconfiguration" "image-admission-config" "true" 300
+    deleteResourceInGlobalNamespace "validatingwebhookconfiguration" "image-admission-config" "true" 300
     result=$(( result + $? ))
     #deleteCRDs
     #result=$(( result + $? ))

--- a/scripts/cp4mcm-cleanup-utility.sh
+++ b/scripts/cp4mcm-cleanup-utility.sh
@@ -330,6 +330,51 @@ deleteResource() {
     return 0
 }
 
+deleteResourceInGlobalNamespace() {
+    resourceType=$1
+    resourceName=$2
+
+    if [[ "${resourceName}" == "" ]]; then
+	echo "The resourceName argument was null" >> $logpath
+	return 0
+    fi
+
+    $ocOrKubectl get "${resourceType}" "${resourceName}" --kubeconfig="${pathToKubeconfig}" > /dev/null 2>&1
+    local result=$?
+    if [[ "${result}" -ne 0 ]]; then
+	echo "${resourceType}: ${resourceName} does not exist; skipping deletion attempt" | tee -a "$logpath"
+	echo "" | tee -a "$logpath"
+	return 0
+    fi
+
+    echo "Deleting ${resourceType}: ${resourceName}" | tee -a "$logpath"
+    echo "" | tee -a "$logpath"
+    
+    $ocOrKubectl delete "${resourceType}" "${resourceName}" --force --grace-period=0 --kubeconfig="${pathToKubeconfig}" & >> $logpath
+    local result=$?
+    if [[ "${result}" -ne 0 ]]; then
+	return 1
+    fi
+
+    echo "" | tee -a "$logpath"
+
+    sleep 3s
+
+    $ocOrKubectl get "${resourceType}" "${resourceName}" --kubeconfig="${pathToKubeconfig}" > /dev/null 2>&1
+    local result=$?
+    if [[ "${result}" -ne 1 ]]; then
+	echo "Resource still exists; attempting to remove finalizers from resource" | tee -a "$logpath"
+	echo "" | tee -a "$logpath"
+	patchString='{"metadata":{"finalizers": []}}'
+	$ocOrKubectl patch "${resourceType}" "${resourceName}" -p "$patchString" --type=merge --kubeconfig="${pathToKubeconfig}" >> $logpath
+	local result=$?
+	if [[ "${result}" -ne 0 ]]; then
+	    return 1
+	fi
+    fi
+    return 0
+}
+
 
 deleteKind() {
     local kind=$1
@@ -743,6 +788,10 @@ secretConfigmapFunc() {
     result=$(( result + $? ))
     deleteResource "secret" "kube-system" "ibm-management-pull-secret" "true" 300
     result=$(( result + $? ))
+	deleteResourceInGlobalNamespace "mutatingwebhookconfiguration" "image-admission-config" "true" 300
+    result=$(( result + $? ))
+	deleteResourceInGlobalNamespace "validatingwebhookconfiguration" "image-admission-config" "true" 300
+    result=$(( result + $? ))
     if [[ "${result}" -ne 0 ]]; then
 	return 1
 	echo "Did not successfully complete secretConfigmapCleanup" | tee -a "$logpath"
@@ -776,6 +825,10 @@ postUninstallFunc() {
     deleteResource "secret" "openshift-operators" "ibm-management-pull-secret" "true" 300
     result=$(( result + $? ))
     deleteResource "secret" "kube-system" "ibm-management-pull-secret" "true" 300
+    result=$(( result + $? ))
+	deleteResourceInGlobalNamespace "mutatingwebhookconfiguration" "image-admission-config" "true" 300
+    result=$(( result + $? ))
+	deleteResourceInGlobalNamespace "validatingwebhookconfiguration" "image-admission-config" "true" 300
     result=$(( result + $? ))
     #deleteCRDs
     #result=$(( result + $? ))

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -834,9 +834,9 @@ uninstallInstallationFunc() {
     result=$(( result + $? ))
     deleteResource "secret" "kube-system" "ibm-management-pull-secret" "true" 300
     result=$(( result + $? ))
-	deleteResourceInGlobalNamespace "mutatingwebhookconfiguration" "image-admission-config" "true" 300
+    deleteResourceInGlobalNamespace "mutatingwebhookconfiguration" "image-admission-config" "true" 300
     result=$(( result + $? ))
-	deleteResourceInGlobalNamespace "validatingwebhookconfiguration" "image-admission-config" "true" 300
+    deleteResourceInGlobalNamespace "validatingwebhookconfiguration" "image-admission-config" "true" 300
     result=$(( result + $? ))
     if [[ "${result}" -ne 0 ]]; then
 	return 1

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -351,6 +351,50 @@ deleteResource() {
     return 0
 }
 
+deleteResourceInGlobalNamespace() {
+    resourceType=$1
+    resourceName=$2
+
+    if [[ "${resourceName}" == "" ]]; then
+	echo "The resourceName argument was null" >> $logpath
+	return 0
+    fi
+
+    $ocOrKubectl get "${resourceType}" "${resourceName}" --kubeconfig="${pathToKubeconfig}" > /dev/null 2>&1
+    local result=$?
+    if [[ "${result}" -ne 0 ]]; then
+	echo "${resourceType}: ${resourceName} does not exist; skipping deletion attempt" | tee -a "$logpath"
+	echo "" | tee -a "$logpath"
+	return 0
+    fi
+
+    echo "Deleting ${resourceType}: ${resourceName}" | tee -a "$logpath"
+    echo "" | tee -a "$logpath"
+    
+    $ocOrKubectl delete "${resourceType}" "${resourceName}" --force --grace-period=0 --kubeconfig="${pathToKubeconfig}" & >> $logpath
+    local result=$?
+    if [[ "${result}" -ne 0 ]]; then
+	return 1
+    fi
+
+    echo "" | tee -a "$logpath"
+
+    sleep 3s
+
+    $ocOrKubectl get "${resourceType}" "${resourceName}" --kubeconfig="${pathToKubeconfig}" > /dev/null 2>&1
+    local result=$?
+    if [[ "${result}" -ne 1 ]]; then
+	echo "Resource still exists; attempting to remove finalizers from resource" | tee -a "$logpath"
+	echo "" | tee -a "$logpath"
+	patchString='{"metadata":{"finalizers": []}}'
+	$ocOrKubectl patch "${resourceType}" "${resourceName}" -p "$patchString" --type=merge --kubeconfig="${pathToKubeconfig}" >> $logpath
+	local result=$?
+	if [[ "${result}" -ne 0 ]]; then
+	    return 1
+	fi
+    fi
+    return 0
+}
 
 deleteKind() {
     local kind=$1
@@ -789,6 +833,10 @@ uninstallInstallationFunc() {
     deleteResource "secret" "openshift-operators" "ibm-management-pull-secret" "true" 300
     result=$(( result + $? ))
     deleteResource "secret" "kube-system" "ibm-management-pull-secret" "true" 300
+    result=$(( result + $? ))
+	deleteResourceInGlobalNamespace "mutatingwebhookconfiguration" "image-admission-config" "true" 300
+    result=$(( result + $? ))
+	deleteResourceInGlobalNamespace "validatingwebhookconfiguration" "image-admission-config" "true" 300
     result=$(( result + $? ))
     if [[ "${result}" -ne 0 ]]; then
 	return 1


### PR DESCRIPTION
Resolves https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/23511

- Added deletion command for `MutatingWebhookConfiguration` object
- Added deletion command for `ValidatingWebhookConfiguration` object

Tested the `cp4mcm-cleanup-utility.sh` and confirmed these changes works as expected. Both objects were deleted after running the `postUninstallCleanup`. 

Ready to merge.