### PR TITLE
Remove usage of PodSecurityPolicy as not supported on OCP 4.12 & K8S 1.25 onwards

### DIFF
--- a/monitoring/2.3/plugin-repo-deploy.yaml
+++ b/monitoring/2.3/plugin-repo-deploy.yaml
@@ -1,29 +1,3 @@
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: "plugin-repo"
-spec:
-  privileged: false
-  allowPrivilegeEscalation: false
-  allowedCapabilities:
-  - '*'
-  volumes:
-  - '*'
-  hostNetwork: true
-  hostPorts:
-  - min: 0
-    max: 65535
-  hostIPC: true
-  hostPID: true
-  runAsUser:
-    rule: 'RunAsAny'
-  seLinux:
-    rule: 'RunAsAny'
-  supplementalGroups:
-    rule: 'RunAsAny'
-  fsGroup:
-    rule: 'RunAsAny'
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -39,14 +13,6 @@ rules:
   - '*'
   verbs:
   - '*'
-- apiGroups:
-  - extensions
-  resourceNames:
-  - "plugin-repo"
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/monitoring/2.3/ua-operator-deploy.yaml
+++ b/monitoring/2.3/ua-operator-deploy.yaml
@@ -1,29 +1,3 @@
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: "ua-operator"
-spec:
-  privileged: false
-  allowPrivilegeEscalation: false
-  allowedCapabilities:
-  - '*'
-  volumes:
-  - '*'
-  hostNetwork: true
-  hostPorts:
-  - min: 0
-    max: 65535
-  hostIPC: true
-  hostPID: true
-  runAsUser:
-    rule: 'RunAsAny'
-  seLinux:
-    rule: 'RunAsAny'
-  supplementalGroups:
-    rule: 'RunAsAny'
-  fsGroup:
-    rule: 'RunAsAny'
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -46,14 +20,6 @@ rules:
   - '*'
   verbs:
   - '*'
-- apiGroups:
-  - extensions
-  resourceNames:
-  - "ua-operator"
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/scripts/cnmon/2.3/operator.yaml
+++ b/scripts/cnmon/2.3/operator.yaml
@@ -28,14 +28,14 @@ spec:
         productMetric: "MANAGED_VIRTUAL_SERVER"
         productChargedContainers: "All"
         productCloudpakRatio: "1:1"
-        olm.relatedImage.autconfigoperator: cp.icr.io/cp/cp4mcm/ibm-dc-autoconfig-operator@sha256:b3ecb5920daaa08009111c3ba303dae1a8f0919de7a2b6919e09b9a3a01e7a55
-        olm.relatedImage.k8monitor: cp.icr.io/cp/cp4mcm/k8-monitor@sha256:bde6cb952fded7a143de56b3931651a171cd95d85096dd9bd12656e2234aa442
-        olm.relatedImage.k8operator: cp.icr.io/cp/cp4mcm/k8sdc-operator@sha256:f04707be1fd0155405660948a19a5f7dd752ad8e645d91c433f17be9d0763d72
-        olm.relatedImage.reloader: cp.icr.io/cp/cp4mcm/reloader@sha256:3d3942ed5bd4813598eb1940aa2f2cc23e99768394c7da2c7efd6ec196f0b704
-        olm.relatedImage.uacloud: cp.icr.io/cp/cp4mcm/ua-cloud-monitoring@sha256:71e8ddc8ed82d09e78c2d9b475572194a0ae032904c759b9ef553a0b2940e733
-        olm.relatedImage.uaoperator: cp.icr.io/cp/cp4mcm/ua-operator@sha256:12ad6a21e2018fbb1ad0f9a5acb1735a48a6ab9c25e29142a9a764cc2afe3449
-        olm.relatedImage.uaplugins: cp.icr.io/cp/cp4mcm/ua-plugins@sha256:7a741e979be05a146a6eb50601859a6f87f9e768a16e9f691ca19f6990b57fae
-        olm.relatedImage.uarepo: cp.icr.io/cp/cp4mcm/ua-repo@sha256:102f916534fd7d915e2ee0e25cd59bb9413a2aa5887e1b1ce8df04728070f827
+        olm.relatedImage.autconfigoperator: cp.icr.io/cp/cp4mcm/ibm-dc-autoconfig-operator@sha256:0bfd824200a4bbe6b13d7ccbd47c105804e03b2508db34afc953e54bdd1912b8
+        olm.relatedImage.k8monitor: cp.icr.io/cp/cp4mcm/k8-monitor@sha256:608eef0ef3cdd37a2001459f0734d337c259cb07a572cc69c1e7614d3c0199a0
+        olm.relatedImage.k8operator: cp.icr.io/cp/cp4mcm/k8sdc-operator@sha256:51016382d2bf80560265375563de4493d7bcd41763b33fdcdb5e2a3610139f06
+        olm.relatedImage.reloader: cp.icr.io/cp/cp4mcm/reloader@sha256:9000f8c2e4c98cc6380b4d4917165e56b029acc760bba588d79e2dc7043ebffb
+        olm.relatedImage.uacloud: cp.icr.io/cp/cp4mcm/ua-cloud-monitoring@sha256:2592f1ee65ccc226a4ec4835d2b965b65de97bb05117f9719d925383c6b789f7
+        olm.relatedImage.uaoperator: cp.icr.io/cp/cp4mcm/ua-operator@sha256:1c51860655cbb01ddf58ac6adfe2f1347554d6fbdd1a262bf69be46040c37bff
+        olm.relatedImage.uaplugins: cp.icr.io/cp/cp4mcm/ua-plugins@sha256:cadcc8e5f16f758a95ac3d757eb347e4af7840dce19ac9a169fe6e5a6907abe4
+        olm.relatedImage.uarepo: cp.icr.io/cp/cp4mcm/ua-repo@sha256:e2ff477c9b810d1293494c8dfc2d3383df9d3a316d3bdbcef339bb8520d7074d
     spec:
       serviceAccountName: ibm-monitoring-dataprovider-mgmt-operator
       hostNetwork: false
@@ -58,7 +58,7 @@ spec:
       containers:
         - name: operator
           # Replace this with the built image name
-          image: cp.icr.io/cp/cp4mcm/ibm-monitoring-dataprovider-mgmt-operator@sha256:3a603cda2c6af31655b0bdf9062d3c99e32653b474ad9b20cdf4264fd92ae64f
+          image: cp.icr.io/cp/cp4mcm/ibm-monitoring-dataprovider-mgmt-operator@sha256:ca85ff5747b6d02aa5fe484e206fd05f3810cca6f9c011cf24ed1f73db24d4d9
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
@@ -108,6 +108,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.annotations['olm.relatedImage.uaplugins']
+            - name: PRODVER
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['productVersion']
           livenessProbe:
             httpGet:
               path: /healthz

--- a/scripts/cnmon/2.3/role.yaml
+++ b/scripts/cnmon/2.3/role.yaml
@@ -17,9 +17,3 @@ rules:
   - '*'
   verbs:
   - '*'
-- apiGroups:
-  - extensions
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use

--- a/scripts/cnmon/2.3/uninstall_cnmon.sh
+++ b/scripts/cnmon/2.3/uninstall_cnmon.sh
@@ -309,15 +309,6 @@ for i in "${clusterrole[@]}"; do
   kubectl delete clusterrole $i
 done
 
-echo "Search and deleting podsecuritypolicy..."
-podsecuritypolicy=$(kubectl get podsecuritypolicy ua-operator --no-headers=true --ignore-not-found=true | awk '{print $1}')
-if [ -z "$podsecuritypolicy" ]
-then
-  echo "No related podsecuritypolicy found."
-else
-  kubectl delete podsecuritypolicy $podsecuritypolicy
-fi
-
 echo ""
 if [ ! $nscnt -eq 0 -a $keep_uacr = false -a "$namespace" != "management-monitoring" ]
 then


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/24502 
https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/24328
https://docs.openshift.com/container-platform/4.12/release_notes/ocp-4-12-release-notes.html#ocp-4-12-removed-features
https://kubernetes.io/docs/reference/using-api/deprecation-guide/
